### PR TITLE
Update AppsFlyer assembly reference

### DIFF
--- a/Runtime/DeBox.Analytics.asmdef
+++ b/Runtime/DeBox.Analytics.asmdef
@@ -4,7 +4,7 @@
         "DeBox.PlayerPrefsExtensions",
         "com.newtonsoft.json",
         "Mixpanel",
-        "AppsFlyerSDK"
+        "AppsFlyer"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.debox.analytics",
 	"description": "Unity Analytics Management system",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"unity": "2019.3",
 	"displayName": "DeBox Analytics",
 	"dependencies": {}


### PR DESCRIPTION
AppsFlyer assembly is now called AppsFlyer instead of AppsFlyerSDK