### PR TITLE
Fixes to AddToList and UnionList

### DIFF
--- a/Runtime/DeBox/Analytics/DebugManager/DebugAnalyticsManager.cs
+++ b/Runtime/DeBox/Analytics/DebugManager/DebugAnalyticsManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using DeBox.PlayerPrefsExtensions;
 using Newtonsoft.Json;
@@ -269,6 +270,16 @@ namespace DeBox.Analytics.DebugManager
         {
             var data = _playerDataStore.Value;
             _playerData = JsonConvert.DeserializeObject<Dictionary<string, object>>(data);
+            var keys = _playerData.Keys.ToArray();
+            foreach (var k in keys)
+            {
+                var v = _playerData[k];
+                if (v.GetType() == typeof(Newtonsoft.Json.Linq.JArray))
+                {
+                    v = ((Newtonsoft.Json.Linq.JArray)v).ToObject<List<object>>();
+                    _playerData[k] = v;
+                }
+            }
         }
 
         private void StorePlayerData()

--- a/Runtime/DeBox/Analytics/MixPanelManager/MixPanelAnalyticsManager.cs
+++ b/Runtime/DeBox/Analytics/MixPanelManager/MixPanelAnalyticsManager.cs
@@ -104,7 +104,7 @@ namespace DeBox.Analytics.MixPanelManager
         /// <exception cref="NotImplementedException"></exception>
         public override  void UnionList(string attribute, params object[] values)
         {
-            throw new NotImplementedException();
+            Mixpanel.People.Union(attribute, ObjectToValue(values));
         }
 
         /// <summary>
@@ -258,7 +258,8 @@ namespace DeBox.Analytics.MixPanelManager
                    AnalyticsFeatureType.AccountAddToList |
                    AnalyticsFeatureType.SetGlobalEventAttribute | 
                    AnalyticsFeatureType.NamedEventsWithNamedAttributes |
-                   AnalyticsFeatureType.SetGlobalEventAttributeOnce;
+                   AnalyticsFeatureType.SetGlobalEventAttributeOnce
+                   | AnalyticsFeatureType.AccountUnionList;
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.debox.analytics",
 	"description": "Unity Analytics Management system",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"unity": "2019.3",
 	"displayName": "DeBox Analytics",
 	"dependencies": {}


### PR DESCRIPTION
Enabled UnionList for MixPanelAnalyticsManager

Fixed an issue with the DebugAnalyticsManager where it would throw an exception when working with list properties.